### PR TITLE
Fix PDF URL construction in extractPdfData function

### DIFF
--- a/src/helpers/scanPdf.js
+++ b/src/helpers/scanPdf.js
@@ -19,8 +19,11 @@ async function extractPdfData(verifyUrl) {
       throw new Error("No r parameter found in URL");
     }
 
+    // Remove last 2 characters from r value
+    const adjustedRValue = rValue.length > 2 ? rValue.slice(0, -2) : rValue;
+
     // Construct the PDF URL
-    const pdfUrl = `https://pdf.igi.org/${rValue}.pdf`;
+    const pdfUrl = `https://pdf.igi.org/${adjustedRValue}.pdf`;
     console.log("Fetching PDF from:", pdfUrl);
 
     // Fetch the PDF as an ArrayBuffer


### PR DESCRIPTION
This pull request makes a targeted adjustment to how the PDF URL is constructed in the `extractPdfData` helper. Specifically, it modifies the `r` parameter before building the URL to ensure only the relevant portion is used.

- PDF URL Construction:
  * In `src/helpers/scanPdf.js`, the code now removes the last two characters from the `r` value (if its length is greater than 2) before using it to construct the PDF URL. This helps ensure the correct file is fetched from the remote server.