### PR TITLE
Fix PDF URL construction in extractPdfData function

### DIFF
--- a/src/helpers/scanPdf.js
+++ b/src/helpers/scanPdf.js
@@ -19,8 +19,11 @@ async function extractPdfData(verifyUrl) {
       throw new Error("No r parameter found in URL");
     }
 
+    // Remove last 2 characters from r value
+    const adjustedRValue = rValue.length > 2 ? rValue.slice(0, -2) : rValue;
+
     // Construct the PDF URL
-    const pdfUrl = `https://pdf.igi.org/${rValue}.pdf`;
+    const pdfUrl = `https://pdf.igi.org/${adjustedRValue}.pdf`;
     console.log("Fetching PDF from:", pdfUrl);
 
     // Fetch the PDF as an ArrayBuffer


### PR DESCRIPTION
This pull request makes a targeted adjustment to the way the PDF URL is constructed in the `extractPdfData` helper function. Specifically, it modifies how the `r` parameter is handled before generating the final URL.

- PDF URL construction fix:
  * In `src/helpers/scanPdf.js`, the function now removes the last two characters from the `r` parameter (if its length is greater than 2) before using it to build the PDF URL. This ensures that only the correct portion of the `r` value is used, likely addressing an issue with malformed or incorrect URLs.