### PR TITLE
Reset purchase state on edit page load

### DIFF
--- a/src/pages/Admin/Purchase/Edit.js
+++ b/src/pages/Admin/Purchase/Edit.js
@@ -20,6 +20,7 @@ import MainCard from "ui-component/cards/MainCard";
 import withRouter from "src/helpers/withRouter";
 import { withSnackbar } from "notistack";
 import { purchaseEdit } from "actions/admin/purchase.actions";
+import { ADMIN_RESET_PURCHASE } from "actionTypes/admin/purchase.types";
 
 class PurchaseEditPage extends Component {
   constructor(props) {
@@ -27,11 +28,12 @@ class PurchaseEditPage extends Component {
 
     this.state = {
       id: this.props.params.id,
-      purchase: this.props.purchase,
+      purchase: null,
     };
   }
 
   componentDidMount() {
+    this.props.dispatch({ type: ADMIN_RESET_PURCHASE });
     this.props.actions.purchaseEdit(this.state.id);
   }
 

--- a/src/pages/SuperAdmin/Purchase/Edit.js
+++ b/src/pages/SuperAdmin/Purchase/Edit.js
@@ -28,11 +28,12 @@ class PurchaseEditPage extends Component {
 
     this.state = {
       id: this.props.params.id,
-      purchase: this.props.purchase,
+      purchase: null,
     };
   }
 
   componentDidMount() {
+    this.props.dispatch({ type: RESET_PURCHASE });
     this.props.actions.purchaseEdit(this.state.id);
   }
 

--- a/src/reducers/admin/purchase.reducer.js
+++ b/src/reducers/admin/purchase.reducer.js
@@ -73,6 +73,7 @@ export default function (state = initialState, action) {
         case ADMIN_RESET_PURCHASE:
             return {
                 ...state,
+                purchase: null,
                 actionCalled: false,
                 createSuccess: false,
                 deleteSuccess: false,

--- a/src/reducers/superadmin/purchase.reducer.js
+++ b/src/reducers/superadmin/purchase.reducer.js
@@ -86,6 +86,7 @@ export default function (state = initialState, action) {
         case RESET_PURCHASE:
             return {
                 ...state,
+                purchase: null,
                 actionCalled: false,
                 createSuccess: false,
                 deleteSuccess: false,


### PR DESCRIPTION
Reset the purchase state when the edit page loads to ensure a clean state for editing. This change improves the user experience by preventing stale data from being displayed.