### PR TITLE
Reset purchase state on edit page load

### DIFF
--- a/src/pages/Admin/Purchase/Edit.js
+++ b/src/pages/Admin/Purchase/Edit.js
@@ -20,6 +20,7 @@ import MainCard from "ui-component/cards/MainCard";
 import withRouter from "src/helpers/withRouter";
 import { withSnackbar } from "notistack";
 import { purchaseEdit } from "actions/admin/purchase.actions";
+import { ADMIN_RESET_PURCHASE } from "actionTypes/admin/purchase.types";
 
 class PurchaseEditPage extends Component {
   constructor(props) {
@@ -27,11 +28,12 @@ class PurchaseEditPage extends Component {
 
     this.state = {
       id: this.props.params.id,
-      purchase: this.props.purchase,
+      purchase: null,
     };
   }
 
   componentDidMount() {
+    this.props.dispatch({ type: ADMIN_RESET_PURCHASE });
     this.props.actions.purchaseEdit(this.state.id);
   }
 

--- a/src/pages/SuperAdmin/Purchase/Edit.js
+++ b/src/pages/SuperAdmin/Purchase/Edit.js
@@ -28,11 +28,12 @@ class PurchaseEditPage extends Component {
 
     this.state = {
       id: this.props.params.id,
-      purchase: this.props.purchase,
+      purchase: null,
     };
   }
 
   componentDidMount() {
+    this.props.dispatch({ type: RESET_PURCHASE });
     this.props.actions.purchaseEdit(this.state.id);
   }
 

--- a/src/reducers/admin/purchase.reducer.js
+++ b/src/reducers/admin/purchase.reducer.js
@@ -73,6 +73,7 @@ export default function (state = initialState, action) {
         case ADMIN_RESET_PURCHASE:
             return {
                 ...state,
+                purchase: null,
                 actionCalled: false,
                 createSuccess: false,
                 deleteSuccess: false,

--- a/src/reducers/superadmin/purchase.reducer.js
+++ b/src/reducers/superadmin/purchase.reducer.js
@@ -86,6 +86,7 @@ export default function (state = initialState, action) {
         case RESET_PURCHASE:
             return {
                 ...state,
+                purchase: null,
                 actionCalled: false,
                 createSuccess: false,
                 deleteSuccess: false,


### PR DESCRIPTION
This pull request improves the handling of purchase editing state for both Admin and SuperAdmin sections by ensuring that the purchase state is reset when editing begins. This helps prevent stale data from being displayed when navigating between different purchase edit pages.

**State management improvements:**

* The `purchase` state is now explicitly set to `null` in the constructor of both `PurchaseEditPage` components to ensure a clean initial state. [[1]](diffhunk://#diff-2424e540f77dc2bd8cc03ef161665d2e5b50700d94e490c1aa3a29819ecc085cR23-R36) [[2]](diffhunk://#diff-6e8751538280ab4e88c04d11db67b57c3b2e31f9288a8ab5374447ef9c407d81L31-R36)
* When the edit page is mounted, a reset action (`ADMIN_RESET_PURCHASE` for Admin and `RESET_PURCHASE` for SuperAdmin) is dispatched to clear any previous purchase data from the Redux store. [[1]](diffhunk://#diff-2424e540f77dc2bd8cc03ef161665d2e5b50700d94e490c1aa3a29819ecc085cR23-R36) [[2]](diffhunk://#diff-6e8751538280ab4e88c04d11db67b57c3b2e31f9288a8ab5374447ef9c407d81L31-R36)
* The reducers for both Admin and SuperAdmin now set `purchase` to `null` when the corresponding reset action is received, ensuring the store is cleared of old purchase data. [[1]](diffhunk://#diff-b5f671fb590345cc7c4c0866973ab9960870c5bdcc2dd09bffc42233cf1a7107R76) [[2]](diffhunk://#diff-f7ced36ea506c64f26f8e86fc74f670d9a5bd76b65f243985d9d220e6735bd1dR89)