### PR TITLE
Enhance sale creation with discount type and fix calculations

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ FRONT_BASE_URL=http://localhost:8080/
 
 
 
-API_URL=https://dev.api.prakriti.one/
+API_URL=https://test.api.prakriti.one/
 
 ##BASE_URL=https://super.prakriti.one/
 ##FRONT_BASE_URL=https://dev.prakriti.one/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22378,6 +22378,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",

--- a/src/actions/axios.js
+++ b/src/actions/axios.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import secureLocalStorage from "react-secure-storage";
 import { getAuthData } from "src/helpers/helper";
 
 const access_token = getAuthData("access_token");
@@ -8,5 +9,29 @@ const instance = axios.create({
     Authorization: access_token ? "Bearer " + access_token : "",
   },
 });
+
+/**
+ * Global auth handling: when the API rejects a request with 401 (the token has
+ * expired — e.g. team/employee tokens expire at 9 AM — or is otherwise invalid),
+ * clear the stored session and reload. The route guards then send the user to the
+ * login page for their panel. Login failures return HTTP 200, so a 401 always
+ * means an invalid/expired token here. The `auth` guard avoids a reload loop on
+ * pages where the user is already logged out.
+ */
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error && error.response && error.response.status === 401) {
+      try {
+        const hasAuth = secureLocalStorage.getItem("auth");
+        if (hasAuth) {
+          secureLocalStorage.removeItem("auth");
+          window.location.reload();
+        }
+      } catch (e) {}
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default instance;

--- a/src/forms/SuperAdmin/PurchaseForm.js
+++ b/src/forms/SuperAdmin/PurchaseForm.js
@@ -113,8 +113,6 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { cartList } from "actions/superadmin/cart.actions";
 import { formValues } from "redux-form";
 
-var GroseData = 0;
-
 // Add this debounce utility function at the top of the file
 const debounce = (func, wait) => {
   let timeout;
@@ -1983,6 +1981,7 @@ class PurchaseForm extends React.Component {
         size_name: "",
         materials: [],
         tax_info: null,
+        gross_weight: "",
         total_weight: 0,
         rate: 0,
         sub_price: 0,
@@ -2073,29 +2072,50 @@ class PurchaseForm extends React.Component {
     }
     productFormValues.materials = [...materials];
 
-    if (key == "weight") {
+    if (key == "weight" && materials.length > 1) {
+      // Gold (index 0) is always displayed net of every other material's weight.
+      // "Gross" is tracked explicitly in productFormValues.gross_weight (per-dialog
+      // state, reset for every new product) so the split stays correct no matter
+      // which field - gold or a stone - is typed first or edited again later.
       if (index == 0) {
-        GroseData = event.target.value;
-      } else {
-        // console.log(materials);
+        // Just remember the typed value as gross - don't rewrite the field the
+        // user is actively typing into here, or every keystroke gets reformatted
+        // out from under them (see handleGoldWeightBlur for the net recompute).
+        productFormValues.gross_weight = materials[0].weight;
 
-        let weight = GroseData;
-        let total_value = 0;
-        for (let index = 1; index < materials.length; index++) {
-          // total_value += Number(materials[index].weight);
-          total_value += convertUnitToGram(
-            productFormValues.materials[index].unit_name,
-            productFormValues.materials[index].weight,
-          );
-          // console.log("------------total value is ", total_value);
+        // Gold weight changed, so the stones' weight (and hence value) that were
+        // entered against the old gross no longer add up - reset them and force
+        // re-entry rather than silently keeping a now-inconsistent total price.
+        for (let i = 1; i < materials.length; i++) {
+          materials[i] = { ...materials[i], weight: "", pakka_weight: "", amount: 0 };
+        }
+        productFormValues.materials = [...materials];
+      } else {
+        if (isEmpty(productFormValues.gross_weight)) {
+          // First stone weight entered before gold's own field was ever typed into:
+          // treat gold's current (pre-edit) display as the implicit gross baseline.
+          let priorOthersTotal = 0;
+          for (let i = 1; i < materials.length; i++) {
+            priorOthersTotal += convertUnitToGram(
+              this.state.productFormValues.materials[i].unit_name,
+              this.state.productFormValues.materials[i].weight,
+            );
+          }
+          productFormValues.gross_weight =
+            (parseFloat(this.state.productFormValues.materials[0].weight) || 0) +
+            priorOthersTotal;
         }
 
-        materials[0].weight = (weight - total_value).toFixed(3);
+        let othersTotal = 0;
+        for (let i = 1; i < materials.length; i++) {
+          othersTotal += convertUnitToGram(materials[i].unit_name, materials[i].weight);
+        }
+        let gross = parseFloat(productFormValues.gross_weight) || 0;
+        materials[0].weight = (gross - othersTotal).toFixed(3);
 
         let prioritySelected = materials[0].purities.filter(
           (itm) => itm.id == materials[0].purity_id,
         );
-        console.log("prioritySelected : ", prioritySelected);
 
         if (productFormValues.product_type == "material") {
           materials[0].pakka_weight =
@@ -2119,6 +2139,42 @@ class PurchaseForm extends React.Component {
         this.calculatePrice();
       },
     );
+  };
+
+  // Gold's own Total Weight field holds whatever the user typed (gross) while
+  // they're still typing. Once they leave the field, net it against every
+  // other material's current weight - deferred to blur so reformatting to
+  // .toFixed(3) on every keystroke doesn't fight the user mid-edit.
+  handleGoldWeightBlur = () => {
+    let productFormValues = { ...this.state.productFormValues };
+    let materials = [...productFormValues.materials];
+    if (materials.length <= 1) return;
+
+    let othersTotal = 0;
+    for (let i = 1; i < materials.length; i++) {
+      othersTotal += convertUnitToGram(materials[i].unit_name, materials[i].weight);
+    }
+    let gross = parseFloat(productFormValues.gross_weight) || 0;
+    materials[0] = { ...materials[0], weight: (gross - othersTotal).toFixed(3) };
+
+    if (productFormValues.product_type == "material") {
+      let prioritySelected = materials[0].purities.filter(
+        (itm) => itm.id == materials[0].purity_id,
+      );
+      materials[0].pakka_weight =
+        prioritySelected[0] && prioritySelected[0].value != ""
+          ? parseFloat(
+              (parseFloat(materials[0].weight) *
+                parseFloat(prioritySelected[0].value)) /
+                100,
+            ).toFixed(3)
+          : parseFloat(materials[0].weight).toFixed(3);
+    }
+
+    productFormValues.materials = materials;
+    this.setState({ productFormValues: productFormValues }, () => {
+      this.calculatePrice();
+    });
   };
 
   updateProductMakingCharge = (event) => {
@@ -4304,6 +4360,11 @@ class PurchaseForm extends React.Component {
                                                     "weight",
                                                   )
                                                 }
+                                                onBlur={
+                                                  materialIndex === 0
+                                                    ? this.handleGoldWeightBlur
+                                                    : undefined
+                                                }
                                                 error={
                                                   materialFormErrors[
                                                     materialIndex
@@ -4528,6 +4589,11 @@ class PurchaseForm extends React.Component {
                                             "weight",
                                           )
                                         }
+                                        onBlur={
+                                          index === 0
+                                            ? this.handleGoldWeightBlur
+                                            : undefined
+                                        }
                                         error={materialFormErrors[index].weight}
                                         disabled={this.isMaterialFormDisabled()}
                                       />
@@ -4656,7 +4722,7 @@ class PurchaseForm extends React.Component {
                         label="TOT.WT(IN GRAM)"
                         variant="outlined"
                         fullWidth
-                        value={GroseData}
+                        value={productFormValues.total_weight}
                         disabled
                       />
                     </Grid>

--- a/src/forms/SuperAdmin/SaleForm.js
+++ b/src/forms/SuperAdmin/SaleForm.js
@@ -369,6 +369,8 @@ class SaleForm extends React.Component {
 
       common_making_discount: "",
 
+      common_making_discount_type: "discount",
+
       unique_materials: [],
 
       admin_details: {
@@ -935,6 +937,11 @@ class SaleForm extends React.Component {
           making_charge: cart.making_charge,
 
           making_charge_discount_percent: cart.making_charge_discount_percent,
+
+          making_charge_discount_type:
+            cart.making_charge_discount_type || "discount",
+
+          making_charge_flat: cart.making_charge_flat || "",
 
           max_making_charge_discount_percent:
             cart.max_making_charge_discount_percent,
@@ -1817,13 +1824,39 @@ class SaleForm extends React.Component {
         );
       }
 
-      let discount_amount = !isAssign
-        ? priceFormat(
-            (making_charge *
-              parseFloat(products[x].making_charge_discount_percent)) /
-              100,
+      let making_disc_type =
+        products[x].making_charge_discount_type || "discount";
+
+      let discount_amount = 0;
+
+      if (!isAssign) {
+        if (making_disc_type == "rate") {
+          /* flat rate: the entered value replaces the making charge directly,
+             mirroring the material flat-rate case. No percentage discount applies. */
+          let flat_raw = products[x].making_charge_flat;
+
+          if (
+            flat_raw !== "" &&
+            flat_raw !== null &&
+            flat_raw !== undefined &&
+            !isNaN(parseFloat(flat_raw))
+          ) {
+            making_charge = priceFormat(parseFloat(flat_raw));
+          }
+
+          products[x].making_charge_discount_percent = 0;
+        } else {
+          let making_disc_value = parseFloat(
+            products[x].making_charge_discount_percent,
           )
-        : 0;
+            ? parseFloat(products[x].making_charge_discount_percent)
+            : 0;
+
+          discount_amount = priceFormat(
+            (making_charge * making_disc_value) / 100,
+          );
+        }
+      }
 
       let total_making_charge = priceFormat(making_charge - discount_amount);
 
@@ -2645,8 +2678,13 @@ class SaleForm extends React.Component {
 
     let { value, max } = event.target;
 
+    /* super admin can give the full 0 - 100 %, others are capped at the per-row max */
     if (value != "") {
-      value = Math.max(Number(0), Math.min(Number(max), Number(value)));
+      if (!this.isSuperAdmin) {
+        value = Math.max(Number(0), Math.min(Number(max), Number(value)));
+      } else {
+        value = Math.max(Number(0), Math.min(Number(100), Number(value)));
+      }
     }
 
     formValues.products[productKey].making_charge_discount_percent = value;
@@ -2797,19 +2835,36 @@ class SaleForm extends React.Component {
   };
 
   handleCommonMakingDis = (event) => {
+    let type = this.state.common_making_discount_type;
+
+    let vl = event.target.value;
+
+    /* percentage discount is allowed only in the 0 - 100 range */
+    if (type != "rate" && vl !== "") {
+      vl = Math.max(Number(0), Math.min(Number(100), Number(vl)));
+    }
+
     this.setState({
-      common_making_discount: event.target.value,
+      common_making_discount: vl,
     });
 
     let formValues = this.state.formValues;
 
-    let vl = event.target.value;
-
     for (let i = 0; i < formValues.products.length; i++) {
-      if (!vl) {
-        formValues.products[i].making_charge_discount_percent = "";
-      } else {
-        if (formValues.products[i].max_making_charge_discount_percent > 0) {
+      formValues.products[i].making_charge_discount_type = type;
+
+      if (formValues.products[i].max_making_charge_discount_percent > 0) {
+        if (type == "rate") {
+          /* flat rate replaces the making charge directly; percentage box shows 0 */
+          formValues.products[i].making_charge_flat = vl;
+          formValues.products[i].making_charge_discount_percent = 0;
+        } else if (!vl) {
+          formValues.products[i].making_charge_discount_percent = "";
+        } else if (this.isSuperAdmin) {
+          /* super admin: reflect the full 0 - 100 value into every row box */
+          formValues.products[i].making_charge_discount_percent = vl;
+        } else {
+          /* others: reflect the entered value but never above the per-row max */
           formValues.products[i].making_charge_discount_percent =
             formValues.products[i].max_making_charge_discount_percent >=
             parseFloat(vl)
@@ -2821,6 +2876,33 @@ class SaleForm extends React.Component {
 
     this.setState(
       {
+        formValues: formValues,
+      },
+
+      () => {
+        this.calculateProductPrice();
+      },
+    );
+  };
+
+  handleCommonMakingDisType = (event) => {
+    let type = event.target.value;
+
+    let formValues = this.state.formValues;
+
+    /* switching the discount mode resets the entered value for every product */
+    for (let i = 0; i < formValues.products.length; i++) {
+      formValues.products[i].making_charge_discount_type = type;
+      formValues.products[i].making_charge_flat = "";
+      /* flat rate forces the row percentage box to 0 */
+      formValues.products[i].making_charge_discount_percent =
+        type == "rate" ? 0 : "";
+    }
+
+    this.setState(
+      {
+        common_making_discount_type: type,
+        common_making_discount: "",
         formValues: formValues,
       },
 
@@ -5214,7 +5296,12 @@ class SaleForm extends React.Component {
                                     max={
                                       item.max_making_charge_discount_percent
                                     }
-                                    disabled={isReturn ? "disabled" : ""}
+                                    disabled={
+                                      isReturn ||
+                                      item.making_charge_discount_type == "rate"
+                                        ? "disabled"
+                                        : ""
+                                    }
                                   />
 
                                   <span
@@ -5436,6 +5523,8 @@ class SaleForm extends React.Component {
                                                             value={item.making_charge_discount_percent}
 
                                                             onChange={(event) => this.handleMakingDiscount(event, index)}
+
+                                                            disabled={item.making_charge_discount_type == "rate"}
 
                                                             InputProps={{
 
@@ -5824,7 +5913,7 @@ class SaleForm extends React.Component {
                                   }
                                   className="custom_input"
                                   style={{
-                                    width: "90%",
+                                    width: "100%",
 
                                     height: "40px",
 
@@ -5843,7 +5932,19 @@ class SaleForm extends React.Component {
                                   }}
                                 >
                                   {" "}
-                                  %
+                                  <select
+                                    value={
+                                      this.state.common_making_discount_type
+                                    }
+                                    onChange={(event) =>
+                                      this.handleCommonMakingDisType(event)
+                                    }
+                                    disabled={isReturn ? "disabled" : ""}
+                                  >
+                                    <option value="discount">Discount %</option>
+
+                                    <option value="rate">Flat rate</option>
+                                  </select>
                                 </span>
                               </span>
                             </div>

--- a/src/forms/SuperAdmin/SaleForm.js
+++ b/src/forms/SuperAdmin/SaleForm.js
@@ -1831,8 +1831,10 @@ class SaleForm extends React.Component {
 
       if (!isAssign) {
         if (making_disc_type == "rate") {
-          /* flat rate: the entered value replaces the making charge directly,
-             mirroring the material flat-rate case. No percentage discount applies. */
+          /* flat rate: the entered value is applied according to the item's
+             sub-category making charge type — multiplied by the total weight
+             for "per_gram" items and by the item quantity for "per_piece"
+             items. No percentage discount applies. */
           let flat_raw = products[x].making_charge_flat;
 
           if (
@@ -1841,7 +1843,17 @@ class SaleForm extends React.Component {
             flat_raw !== undefined &&
             !isNaN(parseFloat(flat_raw))
           ) {
-            making_charge = priceFormat(parseFloat(flat_raw));
+            let flat_rate = parseFloat(flat_raw);
+
+            if (products[x].sub_cat_making_charge_type == "per_gram") {
+              making_charge = priceFormat(
+                flat_rate * parseFloat(products[x].total_weight),
+              );
+            } else if (products[x].sub_cat_making_charge_type == "per_piece") {
+              making_charge = priceFormat(flat_rate * parseFloat(quantity));
+            } else {
+              making_charge = priceFormat(flat_rate);
+            }
           }
 
           products[x].making_charge_discount_percent = 0;
@@ -2855,7 +2867,8 @@ class SaleForm extends React.Component {
 
       if (formValues.products[i].max_making_charge_discount_percent > 0) {
         if (type == "rate") {
-          /* flat rate replaces the making charge directly; percentage box shows 0 */
+          /* flat rate is applied per the item's making charge type (per gram /
+             per piece) during calculation; percentage box shows 0 */
           formValues.products[i].making_charge_flat = vl;
           formValues.products[i].making_charge_discount_percent = 0;
         } else if (!vl) {
@@ -3100,6 +3113,38 @@ class SaleForm extends React.Component {
     }
 
     return haveDis;
+  };
+
+  /* total weight the making discount applies to — the making charge is
+     weight-based only for "per_gram" items, so sum their total weight. */
+  getMakingApplicableWeight = () => {
+    const { formValues } = this.state;
+
+    let weight = 0;
+
+    for (let item of formValues.products) {
+      if (item.sub_cat_making_charge_type == "per_gram") {
+        weight += parseFloat(item.total_weight) || 0;
+      }
+    }
+
+    return weight;
+  };
+
+  /* total quantity the making discount applies to — the making charge is
+     quantity-based only for "per_piece" items, so sum their quantity. */
+  getMakingApplicableQuantity = () => {
+    const { formValues } = this.state;
+
+    let quantity = 0;
+
+    for (let item of formValues.products) {
+      if (item.sub_cat_making_charge_type == "per_piece") {
+        quantity += !isEmpty(item.quantity) ? parseFloat(item.quantity) : 1;
+      }
+    }
+
+    return quantity;
   };
 
   handleCheckBox = (e, index) => {
@@ -5899,9 +5944,12 @@ class SaleForm extends React.Component {
                                 style={{
                                   fontSize: "smaller",
                                   color: "#000000",
+                                  whiteSpace: "nowrap",
                                 }}
                               >
-                                Making Disc
+                                Making Disc (
+                                {this.getMakingApplicableWeight().toFixed(3)} gm
+                                | {this.getMakingApplicableQuantity()} pcs)
                               </p>
 
                               <span style={{ position: "relative" }}>


### PR DESCRIPTION
This pull request introduces significant improvements to both the purchase and sale forms in the SuperAdmin panel, focusing on more accurate handling of material weights (especially gold vs. stones), and a more flexible and robust making charge discount system. It also adds a global API authentication handler and updates the API environment configuration.

**Key changes include:**

### API and Authentication

- **Global 401 error handling:** Added an Axios response interceptor to clear secure local storage and reload the page on authentication failures (HTTP 401), ensuring users are redirected to login when their session expires. (`src/actions/axios.js`) [[1]](diffhunk://#diff-10c8146b52a85229ebd109c111ca9f15a06fbd701c1e6504d19759925a6cd0b7R2) [[2]](diffhunk://#diff-10c8146b52a85229ebd109c111ca9f15a06fbd701c1e6504d19759925a6cd0b7R13-R36)
- **API endpoint update:** Changed the API URL in `.env` to use the test environment. (`.env`)

### Purchase Form (Gold/Stone Weight Logic)

- **Explicit gross/net gold weight handling:** Refactored the logic in `PurchaseForm` so that gold's gross weight is tracked separately from its net weight, recalculating net gold weight based on the sum of all other material weights. This ensures accurate and intuitive editing, especially when stones are involved. (`src/forms/SuperAdmin/PurchaseForm.js`) [[1]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1L116-L117) [[2]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1R1984) [[3]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1L2076-L2098) [[4]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1R2144-R2179) [[5]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1R4363-R4367) [[6]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1R4592-R4596) [[7]](diffhunk://#diff-e8442c03e0c9613e437bf281946121123b4d405eb20d587f47e991fa053943e1L4659-R4725)

### Sale Form (Making Charge Discount System)

- **Flat rate and percentage making charge discounts:** Added support for both flat rate ("rate") and percentage-based ("discount") making charge discounts at both the per-product and common (bulk) level, with logic to apply the correct calculation based on the item's making charge type (per gram or per piece). (`src/forms/SuperAdmin/SaleForm.js`) [[1]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R372-R373) [[2]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R941-R945) [[3]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3L1820-R1872) [[4]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R2850-R2880) [[5]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R2901-R2927)
- **Admin-specific discount limits:** Enforced that only super admins can apply a full 0-100% discount, while others are capped per product's configured maximum. (`src/forms/SuperAdmin/SaleForm.js`)
- **UI/UX improvements for making discounts:** Improved UI to show which units making discounts apply to (grams/pieces), disabled percentage inputs when flat rate is active, and made input fields more user-friendly. (`src/forms/SuperAdmin/SaleForm.js`) [[1]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R3118-R3149) [[2]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3L5217-R5349) [[3]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R5572-R5573) [[4]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3R5947-R5952) [[5]](diffhunk://#diff-07ebc65491d42f46a2d2131816105ded6e6d3455b2f5684945cfc9157b62c4c3L5827-R5964)